### PR TITLE
Fix for issue with visit duration 

### DIFF
--- a/src/Colossus.Integration/App_Config/Include/Colossus/Colossus.config
+++ b/src/Colossus.Integration/App_Config/Include/Colossus/Colossus.config
@@ -1,20 +1,23 @@
 ﻿<?xml version="1.0"?>
 <configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
-  <sitecore>
-    <settings>
-      <setting name="Analytics.AutoDetectBots" value="false" />
-      <setting name="Analytics.Robots.IgnoreRobots" value="false" />
-    </settings>
-    <pipelines>      
-      <initializeTracker>
-        <processor type="Colossus.Integration.PatchTracker, Colossus.Integration" patch:before="*[@type='Sitecore.Analytics.Pipelines.InitializeTracker.RunRules, Sitecore.Analytics']" />
-      </initializeTracker>      
-      <renderLayout>
-        <processor type="Colossus.Integration.GetContextInfo, Colossus.Integration" patch:after="*[last()]" />
-      </renderLayout>
-      <mvc.requestEnd>
-        <processor type="Colossus.Integration.MvcExecuteActions, Colossus.Integration"></processor>
-      </mvc.requestEnd>
-    </pipelines>    
-  </sitecore>  
+    <sitecore>
+        <settings>
+            <setting name="Analytics.AutoDetectBots" value="false" />
+            <setting name="Analytics.Robots.IgnoreRobots" value="false" />
+        </settings>
+        <pipelines>
+            <initializeTracker>
+                <processor type="Colossus.Integration.PatchTracker, Colossus.Integration" patch:before="*[@type='Sitecore.Analytics.Pipelines.InitializeTracker.RunRules, Sitecore.Analytics']" />
+            </initializeTracker>
+            <endAnalytics>
+                <processor type="Colossus.Integration.EndAnalytics, Colossus.Integration" patch:before="*[@type='Sitecore.Analytics.Pipelines.EndAnalytics.ReleaseContact, Sitecore.Analytics']" />
+            </endAnalytics>
+            <renderLayout>
+                <processor type="Colossus.Integration.GetContextInfo, Colossus.Integration" patch:after="*[last()]" />
+            </renderLayout>
+            <mvc.requestEnd>
+                <processor type="Colossus.Integration.MvcExecuteActions, Colossus.Integration"></processor>
+            </mvc.requestEnd>
+        </pipelines>
+    </sitecore>
 </configuration>

--- a/src/Colossus.Integration/Colossus.Integration.csproj
+++ b/src/Colossus.Integration/Colossus.Integration.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Models\PageDefinition.cs" />
     <Compile Include="GetContextInfo.cs" />
     <Compile Include="Models\ItemInfo.cs" />
+    <Compile Include="Pipelines\EndAnalytics.cs" />
     <Compile Include="Processing\ChannelPatcher.cs" />
     <Compile Include="Processing\ContactDataProcessor.cs" />
     <Compile Include="Processing\TriggerEventsAction.cs" />

--- a/src/Colossus.Integration/Pipelines/EndAnalytics.cs
+++ b/src/Colossus.Integration/Pipelines/EndAnalytics.cs
@@ -1,0 +1,47 @@
+﻿using Sitecore.Analytics;
+using Sitecore.Diagnostics;
+using Sitecore.Pipelines;
+using System;
+using System.Web;
+
+namespace Colossus.Integration
+{
+    public class EndAnalytics
+    {
+        public void Process(PipelineArgs args)
+        {
+            Assert.ArgumentNotNull(args, "args");
+            Assert.IsNotNull(Tracker.Current, "Tracker.Current is not initialized");
+
+            if (Tracker.Current == null)
+            {
+                return;
+            }
+
+            try
+            {
+                var requestInfo = HttpContext.Current.ColossusInfo();
+                if (requestInfo == null)
+                {
+                    return;
+                }
+
+                var startDate = DateTime.SpecifyKind(requestInfo.Visit.Start, DateTimeKind.Utc);
+                var endDate = DateTime.SpecifyKind(requestInfo.Visit.End, DateTimeKind.Utc);
+
+                var pageEvents = Tracker.Current.Interaction.CurrentPage.PageEvents;
+
+                foreach (var evnt in pageEvents)
+                {
+                    evnt.DateTime = endDate;
+                    evnt.Timestamp = endDate.Ticks;
+                }
+            }
+            catch (Exception ex)
+            {
+                //Log but ignore errors to avoid interrupting standard analytics
+                Log.Error("xGenerator Colossus.Integration.EndAnalytics failed.", ex, this);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is in relation to issue #35, but I believe it does resolve #36 as well

I found that when generating visits in the past, xGen would correctly patch timestamps on the visit and any custom page events. However, Sitecore Analytics could still kick off other page events for a specific request (ex. error or long running request) and since those are being kicked off at a later point in the execution pipeline, xGen would not be modifying them. The result would be a contact record with page events for the same visit, spanning the full duration of the 'Recency' parameter.

I added a patch to the <endAnalytics> pipeline to modify *all* page events timestamps 