### PR TITLE
Update items related to launchpad icons

### DIFF
--- a/src/serialization/ExmExperienceGenerator/ExmExperienceGenerator.Core.Button/Exm Experience Generator.yml
+++ b/src/serialization/ExmExperienceGenerator/ExmExperienceGenerator.Core.Button/Exm Experience Generator.yml
@@ -13,7 +13,7 @@ SharedFields:
   Value: 200
 - ID: "d25b56d4-23b6-4462-be25-b6a6d7f38e13"
   Hint: Icon
-  Value: Office/32x32/mail_bug.png
+  Value: LaunchPadIcons/32x32/EXM Experience Generator.png
 Languages:
 - Language: en
   Versions:

--- a/src/serialization/ExperienceGenerator/ExperienceGenerator.Core.Application.Contacts.Link/Contact Experience Generator.yml
+++ b/src/serialization/ExperienceGenerator/ExperienceGenerator.Core.Application.Contacts.Link/Contact Experience Generator.yml
@@ -13,7 +13,7 @@ SharedFields:
   Value: 200
 - ID: "d25b56d4-23b6-4462-be25-b6a6d7f38e13"
   Hint: Icon
-  Value: ExperienceGenerator/48x48/Experience Generator.png
+  Value: LaunchPadIcons/48x48/Profile Experience Generator.png
 Languages:
 - Language: en
   Versions:

--- a/src/serialization/ExperienceGenerator/ExperienceGenerator.Core.Application.Link/Experience Generator.yml
+++ b/src/serialization/ExperienceGenerator/ExperienceGenerator.Core.Application.Link/Experience Generator.yml
@@ -13,7 +13,7 @@ SharedFields:
   Value: 200
 - ID: "d25b56d4-23b6-4462-be25-b6a6d7f38e13"
   Hint: Icon
-  Value: ExperienceGenerator/48x48/Experience Generator.png
+  Value: LaunchPadIcons/48x48/Experience Generator.png
 Languages:
 - Language: en
   Versions:


### PR DESCRIPTION
In the scope of LaunchPad redesign work the icons of all apps were changed. In this PR I have updated the definition of the icons to align them with the new LaunchPad design. Please, link my PR with [this issue](https://github.com/Sitecore/xGenerator/issues/68).


**Note:** All icons are located at _Sitecore.Themes_ repository.